### PR TITLE
Fixed some github_changelog_generator warnings about PR

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,3 +1,6 @@
 user=timbilalov
 project=route-builder
 unreleased=false
+release_branch=dev
+# NOTE: Вообще, это не оч. хорошо. Но если включить, то будут дублироваться те PR, которые всего лишь закрывают Issues.
+pulls=false


### PR DESCRIPTION
Поменял в конфиге релизную ветку, но пришлось отключить генерацию лога для PR, потому что тогда выдавало дублирование этих самых PR (хотя они лишь закрывают issues). Короче, пока попробуем так.

Resolves #15 